### PR TITLE
feat: inject sdk6 to sdk7 adaptation layer

### DIFF
--- a/src/explorer/Renderer.tsx
+++ b/src/explorer/Renderer.tsx
@@ -21,6 +21,7 @@ import { createCharacterControllerSystem } from '../lib/babylon/avatars/Characte
 import { createCameraFollowsPlayerSystem } from '../lib/babylon/scene/logic/camera-follows-player'
 import { createCameraObstructionSystem } from '../lib/babylon/scene/logic/hide-camera-obstuction-system'
 import { createLocalAvatarSceneSystem } from '../lib/babylon/scene/logic/local-avatar-scene'
+import { gridToWorld } from '../lib/decentraland/positions'
 
 // we only spend ONE millisecond per frame procesing messages from scenes,
 // it is a conservative number but we want to prioritize CPU time for rendering
@@ -92,6 +93,12 @@ async function main(canvas: HTMLCanvasElement): Promise<BABYLON.Scene> {
     }
   })
 
+  gameConsole.onTeleportRequested.add((position) => {
+    let target: BABYLON.Vector3 = new BABYLON.Vector3()
+    gridToWorld(position.x, position.y, target)
+    characterControllerSystem.teleport(target)
+  })
+
   realmCommunicationSystem.currentRealm.pipe(realm => {
     gameConsole.addConsoleMessage({ message: `🌐 Connected to realm ${realm.aboutResponse.configurations?.realmName}`, isCommand: false })
   })
@@ -144,6 +151,15 @@ async function main(canvas: HTMLCanvasElement): Promise<BABYLON.Scene> {
 
     // create an empty set of desired running scenes
     const desiredRunningScenes = new Map<string, { isGlobal: boolean }>()
+
+    // hack: loads genesis plaza
+    if (realm.baseUrl === 'https://peer.decentraland.org') {
+      // Genesis Plaza
+      //desiredRunningScenes.set('urn:decentraland:entity:bafkreihn2msxftdyd3nxqcbxmmzd252xcqongub3tladzsu557kcsomuui?baseUrl=https://peer.decentraland.org/content/contents/', { isGlobal: false })
+
+      // Asian Plaza
+      desiredRunningScenes.set('urn:decentraland:entity:QmUBjSNgs9MgDJneARJgpsnvEBJQQ1wMfvqmP7J24iQ23R?baseUrl=https://peer.decentraland.org/content/contents/', { isGlobal: false })
+    }
 
     // first load the desired scenes into the desiredRunningScenes set
     avatarSceneRealmSceneUrns.forEach(urn => desiredRunningScenes.set(urn, { isGlobal: true }))

--- a/src/explorer/console.ts
+++ b/src/explorer/console.ts
@@ -31,6 +31,7 @@ export function addChat(canvas: HTMLCanvasElement) {
   const chatCommands: { [key: string]: IChatCommand } = {};
 
   const onChatMessage = new Observable<string>();
+  const onTeleportRequested = new Observable<any>();
 
   parent.setAttribute("class", "console");
   chatInputElement.setAttribute("class", "chatInput");
@@ -212,9 +213,17 @@ export function addChat(canvas: HTMLCanvasElement) {
     clearChat()
   })
 
+  addChatCommand("teleport", "Teleport player to position", async (message) => {
+    const parts = message.split(',')
+    const x = parts[0]
+    const y = parts[1]
+    onTeleportRequested.notifyObservers({ x, y})
+  })
+
   return {
     addConsoleMessage,
     onChatMessage,
+    onTeleportRequested,
     clearChat,
     addChatCommand
   }

--- a/src/lib/babylon/scene/load.ts
+++ b/src/lib/babylon/scene/load.ts
@@ -22,7 +22,7 @@ export async function loadSceneContext(engineScene: BABYLON.Scene, options: { ur
 
   const loadableScene = await getLoadableSceneFromUrl(parsed.entityId, parsed.baseUrl)
 
-  if ((loadableScene.entity.metadata as any).runtimeVersion !== '7') throw new Error('The scene is not compatible with the current runtime version. It may be using SDK6')
+  //if ((loadableScene.entity.metadata as any).runtimeVersion !== '7') throw new Error('The scene is not compatible with the current runtime version. It may be using SDK6')
 
   const ctx = new SceneContext(engineScene, loadableScene, options.isGlobal)
 

--- a/src/lib/common-runtime/startup.ts
+++ b/src/lib/common-runtime/startup.ts
@@ -19,7 +19,18 @@ export async function getStartupData(port: RpcClientPort) {
 
   // look for the "bin/game.js" or similar specified in the .main field
   const mainFileName = scene.main
-  const mainFile = await runtime.readFile({ fileName: mainFileName })
 
-  return { mainFile, scene, mainFileName }
+  const mainFileContent = await async function() {
+    const isSdk7 = (scene as any).runtimeVersion === '7'
+    if (isSdk7) {
+      const res = await runtime.readFile({ fileName: mainFileName })
+      return res.content
+    } else {
+      const res = await fetch('https://renderer-artifacts.decentraland.org/sdk7-adaption-layer/main/index.min.js')
+      return new Uint8Array(await res.arrayBuffer())
+    }
+  }()
+    
+
+  return { mainFileContent, scene, mainFileName }
 }

--- a/src/lib/decentraland/identifiers.ts
+++ b/src/lib/decentraland/identifiers.ts
@@ -2,7 +2,7 @@ export function parseEntityUrn(urn: string): { entityId: string, urn: string, ba
   // many URN formats are valid for Decentraland.
   // for simplicity, at this stage we will only parse one type of URN:
 
-  const matches = urn.match(/^(urn\:decentraland\:entity\:(ba[a-zA-Z0-9]{57}))/)
+  const matches = urn.match(/^(urn\:decentraland\:entity\:([a-zA-Z0-9]+))/)
 
   if (!matches) throw new Error(`The provided URN is not supported: ${urn}`)
 

--- a/src/lib/quick-js/rpc-scene-runtime.ts
+++ b/src/lib/quick-js/rpc-scene-runtime.ts
@@ -16,7 +16,7 @@ import { getStartupData } from '../common-runtime/startup'
 
 // this function starts the scene runtime as explained in ADR-133
 export async function startQuickJsSceneRuntime(port: RpcClientPort, options: RpcSceneRuntimeOptions) {
-  const { mainFile, mainFileName } = await getStartupData(port)
+  const { mainFileContent, mainFileName } = await getStartupData(port)
   await withQuickJsVm(async (opts) => {
     opts.provide({
       ...options,
@@ -26,7 +26,7 @@ export async function startQuickJsSceneRuntime(port: RpcClientPort, options: Rpc
     })
 
     const decoder = new TextDecoder()
-    await opts.eval(decoder.decode(mainFile.content), mainFileName)
+    await opts.eval(decoder.decode(mainFileContent), mainFileName)
 
     await options.updateLoop({ ...opts, isRunning: () => (port.state === 'open') })
   })

--- a/src/lib/web-worker-runtime/web-worker-scene-runtime.ts
+++ b/src/lib/web-worker-runtime/web-worker-scene-runtime.ts
@@ -16,7 +16,7 @@ import { customEvalSdk } from './sandbox'
 
 // this function starts the scene runtime as explained in ADR-133
 export async function startWebWorkerSceneRuntime(port: RpcClientPort, options: RpcSceneRuntimeOptions) {
-  const { mainFile } = await getStartupData(port)
+  const { mainFileContent } = await getStartupData(port)
  
   // first create an empty sandbox
   const context: any = Object.create(null)
@@ -25,7 +25,7 @@ export async function startWebWorkerSceneRuntime(port: RpcClientPort, options: R
 
   // then run the scene
   const decoder = new TextDecoder()
-  const sceneSource = decoder.decode(mainFile.content)
+  const sceneSource = decoder.decode(mainFileContent)
   const enableSceneSourceMaps = true
   await customEvalSdk(sceneSource, context, enableSceneSourceMaps)
 


### PR DESCRIPTION
When an SDK6 Scene is detected, we load the [SDK7 Adaption Layer](https://github.com/decentraland/sdk7-adaption-layer).

The SDK7 Adaption Layer internally reads the scene.json and evaluates the main script from the SDK6 scene.

- Added basic /teleport command

Note:
Due that the Dynamic World Loading is not ready, I added a hack to load the Asian Plaza, and the EntityID has an old format, so now we tolerate formats like `QmUBjSNgs9MgDJneARJgpsnvEBJQQ1wMfvqmP7J24iQ23R` for EntityID.